### PR TITLE
fix: 새로고침 시 graceful close race로 인한 역방향 연결 스킵 해결

### DIFF
--- a/electron/peer/wsClient.js
+++ b/electron/peer/wsClient.js
@@ -76,8 +76,15 @@ function disconnectFromPeer(peerId) {
   }
 }
 
+// OPEN 상태인 연결만 반환 — CLOSING/CLOSED 좀비 소켓은 제외
 function getConnections() {
-  return Array.from(connectionMap.keys())
+  const activeConnections = []
+  connectionMap.forEach((socket, peerId) => {
+    if (socket.readyState === WebSocket.OPEN) {
+      activeConnections.push(peerId)
+    }
+  })
+  return activeConnections
 }
 
 function disconnectAll() {

--- a/electron/peer/wsServer.js
+++ b/electron/peer/wsServer.js
@@ -32,9 +32,10 @@ function stopWsServer({ server }) {
   server.close()
 }
 
-// 서버에 연결된 모든 클라이언트 소켓 강제 종료 (새로고침/재로그인 시 좀비 소켓 정리용)
+// 서버에 연결된 모든 클라이언트 소켓 즉시 종료 (새로고침/재로그인 시 좀비 소켓 정리용)
+// terminate()는 graceful close 없이 즉시 TCP 연결을 끊어 상대방 close 이벤트를 빠르게 발생시킴
 function closeAllServerClients({ server }) {
-  server.clients.forEach((socket) => socket.close())
+  server.clients.forEach((socket) => socket.terminate())
 }
 
 module.exports = { startWsServer, stopWsServer, closeAllServerClients }


### PR DESCRIPTION
## Summary
- v0.6.4의 closeAllServerClients가 graceful close(socket.close()) 사용 → 비동기라 상대방 connectionMap 정리 전에 key-exchange 도착 → 역방향 연결 스킵
- 한쪽만 새로고침하면 연결이 안 되고, 양쪽 다 새로고침해야 연결되던 버그의 실제 원인

## Changes
1. **wsServer.js**: `closeAllServerClients`에서 `socket.terminate()` 사용 — graceful close 없이 즉시 TCP 종료
2. **wsClient.js**: `getConnections()`가 `OPEN` 상태 소켓만 반환 — CLOSING/CLOSED 좀비 소켓 필터링

## Test plan
- [x] `npm test` 24개 테스트 전체 통과
- [ ] A만 새로고침 → B에서 A 자동 재발견 확인
- [ ] A 로그아웃→재로그인 → B에서 A 자동 재발견 확인

Closes #10