### PR TITLE
chore: bump version to 0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lan-chat",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
v0.6.6 릴리즈 - fix: graceful close race 해결 (#10)