### PR TITLE
feat: 스크롤 위일 때 새 메시지 토스트 알림

### DIFF
--- a/src/components/ChatWindow.jsx
+++ b/src/components/ChatWindow.jsx
@@ -99,10 +99,10 @@ export default function ChatWindow() {
     }
   }, [currentMessages, currentRoom])
 
-  // 채팅방 변경 시 항상 하단으로 이동 + 토스트/카운터 초기화
+  // 채팅방 변경 시 항상 하단으로 이동 + 토스트 초기화
+  // prevMessageCountRef는 새 메시지 effect에서 방 변경 감지 시 동기화됨
   useEffect(() => {
     isNearBottomRef.current = true
-    prevMessageCountRef.current = 0
     setNewMessageToast(null)
     scrollEndRef.current?.scrollIntoView({ behavior: 'auto' })
   }, [currentRoom])


### PR DESCRIPTION
## Summary
스크롤이 위에 있을 때 새 메시지가 오면 하단에 흰색 토스트를 표시하여 최신 메시지로 이동 유도

## Changes (ChatWindow.jsx)
- `newMessageToast` state: `{ sender, preview }` 또는 null
- 새 메시지 수신 시 스크롤 위치에 따라 자동 스크롤 or 토스트 표시
- 내 메시지는 토스트 없이 바로 하단 스크롤
- 토스트 클릭 → `scrollToBottom()` → 스크롤 이동 + 토스트 숨김
- 스크롤 하단 도달 시 자동 토스트 숨김
- 채팅방 변경 시 토스트 초기화
- 미리보기: 텍스트 truncate, 이미지/동영상/파일 구분 표시
- 토스트 UI: 흰색 pill, shadow, 중앙 정렬, max-w-[80%]

## Test plan
- [x] npm test 24개 통과
- [ ] 위로 스크롤 후 상대방 메시지 수신 → 토스트 표시 확인
- [ ] 토스트 클릭 → 하단 이동 확인
- [ ] 하단으로 스크롤 → 토스트 자동 사라짐 확인
- [ ] 내가 보낸 메시지 → 토스트 없이 자동 스크롤 확인

Closes #19