### PR TITLE
fix: 내가 보낸 긴 링크 줄바꿈 안 되는 문제

### DIFF
--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -102,7 +102,7 @@ export default function Message({ message }) {
 
           {/* 메시지 내용 */}
           {(contentType === 'text' || !contentType) && (
-            <div className="select-text bg-vsc-panel rounded px-3 py-1.5 text-sm text-vsc-text leading-relaxed whitespace-pre-wrap break-words">
+            <div className="select-text bg-vsc-panel rounded px-3 py-1.5 text-sm text-vsc-text leading-relaxed whitespace-pre-wrap break-words max-w-full">
               {parseLinksInText(message.content || '')}
             </div>
           )}


### PR DESCRIPTION
## Summary
내 메시지의 텍스트 버블에서 긴 URL이 줄바꿈되지 않는 문제 수정

## Root Cause
부모 div에 `items-end`가 적용되어 텍스트 버블 width가 content-fit으로 축소됨.
`max-w-[70%]`는 부모에 있지만, `items-end`로 인해 자식 버블이 content 크기로 줄어들어 `break-words`가 동작하지 않음.

## Fix
텍스트 버블에 `max-w-full` 추가 → 부모의 `max-w-[70%]` 내에서 항상 전체 너비 사용 → `break-words` 정상 동작

## Test plan
- [x] npm test 24개 통과
- [ ] 내가 보낸 긴 URL이 줄바꿈되는지 확인
- [ ] 상대방 메시지 줄바꿈은 기존처럼 동작하는지 확인

Closes #22