### PR TITLE
fix: Cmd+W로 앱이 종료되는 문제

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -843,6 +843,53 @@ async function createWindow() {
     mainWindow.loadFile(path.join(__dirname, '../dist/renderer/index.html'))
   }
 
+  // macOS 앱 메뉴 설정 — Cmd+W를 숨김으로 오버라이드 (기본 Close Window 방지)
+  if (process.platform === 'darwin') {
+    const appMenu = Menu.buildFromTemplate([
+      {
+        label: app.name,
+        submenu: [
+          { role: 'about' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
+      },
+      {
+        label: '편집',
+        submenu: [
+          { role: 'undo' },
+          { role: 'redo' },
+          { type: 'separator' },
+          { role: 'cut' },
+          { role: 'copy' },
+          { role: 'paste' },
+          { role: 'selectAll' },
+        ],
+      },
+      {
+        label: '창',
+        submenu: [
+          {
+            label: '창 닫기',
+            accelerator: 'CmdOrCtrl+W',
+            click: () => {
+              if (mainWindow && !isQuitting) {
+                mainWindow.hide()
+                app.dock?.hide()
+              }
+            },
+          },
+          { role: 'minimize' },
+        ],
+      },
+    ])
+    Menu.setApplicationMenu(appMenu)
+  }
+
   setupAutoUpdater()
 }
 


### PR DESCRIPTION
## Summary
macOS에서 Cmd+W가 기본 메뉴의 Close Window를 호출하여 close 이벤트 가로채기를 우회, 앱이 종료되던 문제 수정

## Fix
커스텀 앱 메뉴에서 Cmd+W를 `mainWindow.hide()` + Dock 숨김으로 오버라이드

## Test plan
- [x] npm test 24개 통과
- [ ] Cmd+W → 창 숨김 + 트레이 유지 확인
- [ ] Cmd+Q → 완전 종료 확인
- [ ] Cmd+C/V/X/Z/A → 편집 기능 정상 동작 확인

Closes #34