### PR TITLE
fix: 트레이 최소화 안정성 개선 — Dock 숨김 제거 + isQuitting 조기 설정 방지

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -826,6 +826,18 @@ async function createWindow() {
   ])
   tray.setContextMenu(trayMenu)
 
+  // Windows/Linux: 트레이 아이콘 클릭으로 창 복원 (macOS는 컨텍스트 메뉴만 지원)
+  if (process.platform !== 'darwin') {
+    tray.on('click', () => {
+      if (mainWindow.isVisible()) {
+        mainWindow.focus()
+      } else {
+        mainWindow.show()
+        mainWindow.focus()
+      }
+    })
+  }
+
   if (isDev) {
     mainWindow.loadURL('http://localhost:5173')
   } else {


### PR DESCRIPTION
## Summary
개발자 3명 분석 결과 반영. 코드 로직에는 버그가 없었으나 macOS 플랫폼 특성으로 인한 문제.

## Root Causes
1. **app.dock?.hide()**: Dock 숨김 시 background agent 상태 전환 → show() 해도 포커스 안 잡힘
2. **tray.on('click')**: macOS에서 setContextMenu와 충돌하여 실행 안 됨 (dead code)
3. **before-quit에서 isQuitting 조기 설정**: cleanup 전에 true가 되면 close 핸들러가 종료 허용

## Changes
- `app.dock?.hide()` 전면 제거 (5곳) — Dock 아이콘 유지 (Discord/Slack 방식)
- `tray.on('click')` 핸들러 제거
- `before-quit`에서 `isQuitting`을 `hasCleanedUp` 이후에만 true 설정
- 트레이 메뉴 "열기" + activate에서 `focus()` 추가

## Test plan
- [x] npm test 24개 통과
- [ ] Cmd+W → 창 숨김 (앱 종료 안 됨) + Dock 아이콘 유지
- [ ] 빨간 X → 동일하게 창 숨김
- [ ] Dock 아이콘 클릭 → 창 복원 + 포커스
- [ ] 트레이 → 열기 → 창 복원
- [ ] Cmd+Q → 완전 종료

Closes #37