### PR TITLE
feat: 알림 클릭 시 채팅방 이동 + 창 복원 (슬랙 스타일)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -50,9 +50,24 @@ function sendToRenderer(channel, data) {
   }
 }
 
-function showNotification(title, body) {
+// 알림 표시 — 클릭 시 창 복원 + 해당 채팅방으로 이동
+// navigateTo: { type: 'global' } 또는 { type: 'dm', peerId, nickname }
+function showNotification(title, body, navigateTo) {
   if (!Notification.isSupported()) return
-  new Notification({ title, body: body?.slice(0, 100) || '' }).show()
+  const iconPath = isDev
+    ? path.join(__dirname, '../logo.png')
+    : path.join(process.resourcesPath, 'logo.png')
+  const notification = new Notification({ title, body: body?.slice(0, 100) || '', icon: iconPath })
+  notification.on('click', () => {
+    if (mainWindow) {
+      mainWindow.show()
+      mainWindow.focus()
+    }
+    if (navigateTo) {
+      sendToRenderer('navigate-to-room', navigateTo)
+    }
+  })
+  notification.show()
 }
 
 // 창이 비활성화 상태일 때 렌더러에 소리 재생 요청
@@ -305,7 +320,8 @@ async function initApp() {
         if (mainWindow && !mainWindow.isFocused()) {
           showNotification(
             `${message.from || '알 수 없음'} (DM)`,
-            decryptedPayload.content || '파일을 보냈습니다.'
+            decryptedPayload.content || '파일을 보냈습니다.',
+            { type: 'dm', peerId: message.fromId, nickname: message.from || '알 수 없음' }
           )
           playNotificationSound()
         }
@@ -339,7 +355,8 @@ async function initApp() {
     if (mainWindow && !mainWindow.isFocused()) {
       showNotification(
         message.from || '알 수 없음',
-        message.content || '파일을 보냈습니다.'
+        message.content || '파일을 보냈습니다.',
+        { type: 'global' }
       )
       playNotificationSound()
     }

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -82,6 +82,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('pending-messages-flushed', (_, data) => callback(data))
   },
 
+  // 알림 클릭 시 채팅방 이동
+  onNavigateToRoom: (callback) => {
+    ipcRenderer.removeAllListeners('navigate-to-room')
+    ipcRenderer.on('navigate-to-room', (_, room) => callback(room))
+  },
+
   // 이벤트 구독 해제
   unsubscribeAll: () => {
     ipcRenderer.removeAllListeners('message-received')
@@ -92,6 +98,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.removeAllListeners('peer-profile-updated')
     ipcRenderer.removeAllListeners('pending-messages-flushed')
     ipcRenderer.removeAllListeners('read-receipt')
+    ipcRenderer.removeAllListeners('navigate-to-room')
     ipcRenderer.removeAllListeners('play-notification-sound')
     ipcRenderer.removeAllListeners('update-available')
     ipcRenderer.removeAllListeners('update-download-progress')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -222,6 +222,12 @@ export default function App() {
         playNotification()
       })
 
+      // 알림 클릭 시 해당 채팅방으로 이동
+      window.electronAPI.onNavigateToRoom((room) => {
+        const { setCurrentRoom } = useChatStore.getState()
+        setCurrentRoom(room)
+      })
+
       // 피어 발견 시작 — 구독 등록 후 시작해야 race condition 방지
       await window.electronAPI.startPeerDiscovery()
     }


### PR DESCRIPTION
## Summary
슬랙처럼 알림 클릭 시 해당 채팅방으로 이동 + 숨긴 창 복원

## Changes
- **main.js**: showNotification에 navigateTo 파라미터, 클릭 시 show+focus+navigate
- **preload.js**: onNavigateToRoom API + unsubscribeAll
- **App.jsx**: navigate-to-room 이벤트로 setCurrentRoom 호출

## Test plan
- [x] npm test 24개 통과
- [ ] 트레이 최소화 상태에서 DM 수신 → 알림 표시 확인
- [ ] 알림 클릭 → 창 복원 + 해당 DM방 이동 확인
- [ ] 전체채팅 알림 클릭 → 전체채팅으로 이동 확인

Closes #40