### PR TITLE
fix: 텍스트 뒤에서 코드블록 입력 시 변환 안 되는 문제

### DIFF
--- a/src/components/MessageInput.jsx
+++ b/src/components/MessageInput.jsx
@@ -68,23 +68,19 @@ export default function MessageInput() {
         }
         return false
       },
-      // 백틱 입력 감지 — 텍스트 뒤에서 ``` 완성 시 현재 줄을 분할하고 코드블록 삽입
+      // 백틱 입력 감지 — ``` 완성 시 코드블록 삽입
       handleTextInput: (view, from, to, text) => {
         if (text !== '`') return false
         const { state } = view
         const { $from } = state.selection
-        // 현재 줄의 커서 앞 텍스트 확인
+        // 코드블록 안에서는 일반 텍스트로 입력 (변환하지 않음)
+        if ($from.parent.type.name === 'codeBlock') return false
+        // 커서 앞 텍스트가 ``로 끝나는지 확인 (지금 `를 추가하면 ```가 됨)
         const textBefore = $from.parent.textContent.slice(0, $from.parentOffset)
-        // 이미 ``가 있고 지금 `를 추가하면 ```가 되는 경우
         if (!textBefore.endsWith('``')) return false
-        // 줄 시작이 ```이면 기본 InputRule에 맡김
-        const lineText = textBefore + '`'
-        if (lineText.trimStart() === '```') return false
-        // 텍스트 뒤에서 ``` → 백틱 3개 삭제 후 코드블록 삽입
+        // `` 삭제 + 코드블록 삽입
         const { tr } = state
-        // `` 삭제 (현재 입력될 `는 아직 삽입 안 됨)
         tr.delete(from - 2, from)
-        // 현재 위치에서 줄을 분할하고 코드블록 삽입
         const codeBlock = state.schema.nodes.codeBlock.create()
         tr.replaceSelectionWith(codeBlock)
         view.dispatch(tr)


### PR DESCRIPTION
CodeBlockShortcut Extension 추가. 줄 어디서든 ``` 입력 시 코드블록 변환. Closes #46